### PR TITLE
Enhance SSH tunnel error handling to include permission denied case

### DIFF
--- a/clearml_session/__main__.py
+++ b/clearml_session/__main__.py
@@ -937,7 +937,7 @@ def start_ssh_tunnel(username, remote_address, ssh_port, ssh_password, local_rem
             logfile=fd, timeout=20, encoding='utf-8')
 
         # Match only "(yes/no" in order to handle both (yes/no) and (yes/no/[fingerprint])
-        i = child.expect([r'(?i)password:', r'\(yes\/no', r'.*[$#] ', pexpect.EOF])
+        i = child.expect([r'(?i)password:', r'\(yes\/no', r'.*[$#] ', r'Permission denied \(publickey,password\)', pexpect.EOF])
         if i == 0:
             child.sendline(ssh_password)
             try:
@@ -974,6 +974,8 @@ def start_ssh_tunnel(username, remote_address, ssh_port, ssh_password, local_rem
                     raise ValueError('Incorrect password')
                 except pexpect.TIMEOUT:
                     pass
+        elif i == 3:
+            raise Exception("SSH tunneling failed: please enable password authentication in your SSH client config.")
     except Exception as ex:
         if debug:
             print("ERROR: running local SSH client [{}] failed connecting to {}: {}".format(command, args, ex))


### PR DESCRIPTION
If the user has disabled password authentication in his ssh client configuration the ssh command currently fails without any helpful error message. With this addition the user is hinted to enabling the verbose mode and an according error message is printed.

This is what the error message looks like before this PR in console:
```
SSH tunneling failed, retrying in 3 seconds
Starting SSH tunnel to root@X.X.X.X, port Y
```

And now with this PR applied and verbose mode enabled:
```
Waiting for environment setup to complete [usually about 20-30 seconds, see last log line/s below]

Remote machine is ready
Setting up connection to remote session
Starting SSH tunnel to root@X.X.X.X, port Y
ERROR: running local SSH client [C:\Program Files\OpenSSH\ssh.exe] failed connecting to ['-C', 'root@X.X.X.X', '-p', 'Y', '-o', 'Compression=yes', '-o', 'ServerAliveInterval=10', '-o', 'ServerAliveCountMax=10', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', '-L', 'Z:localhost:Y', '-L', 'T:localhost:U', '-L', 'V:localhost:W']: SSH tunneling failed: please enable password authentication in your SSH client config.
```